### PR TITLE
Return query instead of collection reference

### DIFF
--- a/brick_cloud_firestore/lib/cloud_firestore_provider.dart
+++ b/brick_cloud_firestore/lib/cloud_firestore_provider.dart
@@ -36,8 +36,8 @@ class CloudFirestoreProvider implements brick.Provider<CloudFirestoreModel> {
     final adapter = modelDictionary.adapterFor[T];
 
     final collection = Firestore.instance.collection(adapter.collectionNodeKey);
-    final transformedCollection = QueryCloudFirestoreTransformer(query, collection).asRef;
-    final snapshot = await transformedCollection.getDocuments();
+    final firebaseQuery = QueryCloudFirestoreTransformer(query, collection).asFirebaseQuery;
+    final snapshot = await firebaseQuery.getDocuments();
 
     final futureDocuments = snapshot.documents.map<Future<T>>((snapshot) {
       return adapter.fromCloudFirestore(

--- a/brick_cloud_firestore/lib/src/query_cloud_firestore_transformer.dart
+++ b/brick_cloud_firestore/lib/src/query_cloud_firestore_transformer.dart
@@ -3,7 +3,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 class QueryCloudFirestoreTransformer {
   final brick.Query query;
-  final CollectionReference ref;
+  final Query ref;
 
   QueryCloudFirestoreTransformer(this.query, this.ref);
 
@@ -12,7 +12,7 @@ class QueryCloudFirestoreTransformer {
 
     var composedRef = ref;
     if (query.where != null && query.where.isNotEmpty) {
-      composedRef = query.where.fold<CollectionReference>(composedRef, (acc, condition) {
+      composedRef = query.where.fold<Query>(composedRef, (acc, condition) {
         return expandWhereCondition(condition, acc);
       });
     }
@@ -34,10 +34,10 @@ class QueryCloudFirestoreTransformer {
   /// TODO support associations
   Query expandWhereCondition(
     brick.WhereCondition condition,
-    CollectionReference composedRef,
+    Query composedRef,
   ) {
     if (condition.conditions != null && condition.conditions.isNotEmpty) {
-      return condition.conditions.fold<CollectionReference>(composedRef, (acc, _condition) {
+      return condition.conditions.fold<Query>(composedRef, (acc, _condition) {
         return expandWhereCondition(_condition, acc);
       });
     }

--- a/brick_cloud_firestore/lib/src/query_cloud_firestore_transformer.dart
+++ b/brick_cloud_firestore/lib/src/query_cloud_firestore_transformer.dart
@@ -7,7 +7,7 @@ class QueryCloudFirestoreTransformer {
 
   QueryCloudFirestoreTransformer(this.query, this.ref);
 
-  CollectionReference get asRef {
+  Query get asFirebaseQuery {
     if (query == null) return ref;
 
     var composedRef = ref;
@@ -32,8 +32,10 @@ class QueryCloudFirestoreTransformer {
   /// Recursively append a Firestore `.where` condition to the existing reference
   ///
   /// TODO support associations
-  CollectionReference expandWhereCondition(
-      brick.WhereCondition condition, CollectionReference composedRef) {
+  Query expandWhereCondition(
+    brick.WhereCondition condition,
+    CollectionReference composedRef,
+  ) {
     if (condition.conditions != null && condition.conditions.isNotEmpty) {
       return condition.conditions.fold<CollectionReference>(composedRef, (acc, _condition) {
         return expandWhereCondition(_condition, acc);


### PR DESCRIPTION
When composing where queries, the return value is `Query`. `CollectionReference` is actually a subclass of query as well.